### PR TITLE
Improve cache refresh resilience and health visibility

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,11 +18,29 @@ router.get('/health', async (req, res) => {
     // Try to get cache status to verify services are working
     try {
       const cacheStatus = await cacheService.getCacheStatus()
-      health.cache = {
+      const cacheHealth = {
         status: 'healthy',
-        lastRefresh: cacheStatus.lastRefresh,
-        isRefreshing: cacheStatus.isRefreshing
+        lastSuccessfulRefresh: cacheStatus.lastRefresh,
+        lastFailedRefresh: cacheStatus.lastRefreshFailure,
+        isRefreshing: cacheStatus.isRefreshing,
+        nextRefreshTime: cacheStatus.nextRefreshTime,
+        minutesSinceLastSuccess: cacheStatus.minutesSinceLastSuccess,
+        staleForMinutes: cacheStatus.isStale && typeof cacheStatus.minutesSinceLastSuccess === 'number'
+          ? cacheStatus.minutesSinceLastSuccess
+          : null,
+        isStale: cacheStatus.isStale,
+        failureMoreRecentThanSuccess: cacheStatus.failureMoreRecentThanSuccess,
+        playersDataSize: cacheStatus.playersDataSize,
+        trendingAddDataSize: cacheStatus.trendingAddDataSize,
+        trendingDropDataSize: cacheStatus.trendingDropDataSize
       }
+
+      if (cacheStatus.isStale || cacheStatus.failureMoreRecentThanSuccess) {
+        cacheHealth.status = cacheStatus.isStale ? 'stale' : 'degraded'
+        health.status = 'degraded'
+      }
+
+      health.cache = cacheHealth
     } catch (error) {
       health.cache = {
         status: 'unhealthy',


### PR DESCRIPTION
## Summary
- guard the cache service startup refresh with error handling and queue async recovery when cache checks fail
- record refresh failure metadata and surface detailed cache freshness and staleness information through the /health endpoint

## Testing
- npm test *(fails: Can't find a root directory while resolving tests/automated/jest.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dcbd9c16c88333907e7de35c420ca9